### PR TITLE
Added BLOCKSCOUT_HOST variable to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ LINK_TO_OTHER_EXPLORERS=false
 COIN=ROSE
 CHAIN_ID=42261
 HEALTHY_BLOCKS_PERIOD=4000000
+BLOCKSCOUT_HOST=<explorer.hostname.domain.com>
 
 ETHEREUM_JSONRPC_HTTP_URL=<oasis-web3-gateway-http-endpoint>
 ETHEREUM_JSONRPC_TRACE_URL=<oasis-web3-gateway-http-endpoint>


### PR DESCRIPTION
Signed-off-by: Valentin Bud <valentin.bud@gmail.com>

This variable is also required to have proper URLs displayed on `/api-docs` endpoint.

