### PR TITLE
Change coin name from "ETH" to "ROSE"

### DIFF
--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -1024,7 +1024,7 @@ msgstr ""
 #: lib/block_scout_web/templates/smart_contract/_functions.html.eex:104 lib/block_scout_web/templates/smart_contract/_functions.html.eex:104
 #: lib/block_scout_web/templates/smart_contract/_functions.html.eex:146
 msgid "ETH"
-msgstr ""
+msgstr "ROSE"
 
 #, elixir-format
 #: lib/block_scout_web/templates/api_docs/eth_rpc.html.eex:4


### PR DESCRIPTION
Fixes https://github.com/oasisprotocol/emerald-blockscout/issues/7

Changes coin name from "ETH" to "ROSE". 4d4e4aaf1665663052982b3a6c0f6ebcdb80ecbd only changed "Ether" to "ROSE"
